### PR TITLE
fix: labelElement should return an inline `<label>` instead of block ele `div`

### DIFF
--- a/src/editor/LabelWrapper.jsx
+++ b/src/editor/LabelWrapper.jsx
@@ -21,9 +21,11 @@ const LabelWrapper = (props) => {
       on={!data.always_show && 'click'}
       trigger={
         label_type ? (
-          <Label className={cx(label_type, label_pointing, 'with-popup')}>
+          <label
+            className={cx(label_type, label_pointing, 'with-popup ui label')}
+          >
             {children}
-          </Label>
+          </label>
         ) : (
           <span
             id={`label_ref-${uid}`}
@@ -39,7 +41,9 @@ const LabelWrapper = (props) => {
       {serializeNodes(data.tooltip_content)}
     </Popup>
   ) : (
-    <Label className={cx(label_type, label_pointing)}>{children}</Label>
+    <label className={cx(label_type, label_pointing, 'ui label')}>
+      {children}
+    </label>
   );
 };
 

--- a/src/editor/LabelWrapper.jsx
+++ b/src/editor/LabelWrapper.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Popup, Label } from 'semantic-ui-react';
+import { Popup } from 'semantic-ui-react';
 import cx from 'classnames';
 import {
   serializeNodes,


### PR DESCRIPTION
`makeInlineElement` plugin expects Inline elements returned from ElementEditor. We cannot place block level elements inside inline elements.